### PR TITLE
Fix for verifying commit hash exists step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
       if: ${{ steps.get-commit-hash-for-current-branch.outputs.COMMIT_HASH != '' }}
       run: |
         set +e
-        git cat-file -e ${{ steps.get-commit-hash-for-current-branch.outputs.COMMIT_HASH }}
+        git merge-base --is-ancestor ${{ steps.get-commit-hash-for-current-branch.outputs.COMMIT_HASH }} HEAD
         if [[ $? -eq 0 ]]; then
           echo "[INFO] Commit hash ${{ steps.get-commit-hash-for-current-branch.outputs.COMMIT_HASH }} found."
           CONFIRMED=1


### PR DESCRIPTION
Apparently, `git cat-file -e ${{ steps.get-commit-hash-for-current-branch.outputs.COMMIT_HASH }}` does NOT work.
I am expecting it to advise whether the found commit hash is valid for the current branch and it return whether the commit is valid for the entire repo (even for other branches).
Replacing it with `git merge-base --is-ancestor ${{ steps.get-commit-hash-for-current-branch.outputs.COMMIT_HASH }} HEAD` resolves the issue.